### PR TITLE
Resolve view classes for templates with dashed filenames

### DIFF
--- a/lib/stache/mustache/handler.rb
+++ b/lib/stache/mustache/handler.rb
@@ -93,7 +93,7 @@ module Stache
           return Stache::Mustache::View
         end
 
-        const_name = ActiveSupport::Inflector.camelize(template.virtual_path.to_s)
+        const_name = ActiveSupport::Inflector.camelize(ActiveSupport::Inflector.underscore(template.virtual_path.to_s))
         const_name = "#{Stache.wrapper_module_name}::#{const_name}" if Stache.wrapper_module_name
         begin
           const_name.constantize

--- a/spec/stache/mustache/handler_spec.rb
+++ b/spec/stache/mustache/handler_spec.rb
@@ -16,6 +16,12 @@ describe Stache::Mustache::Handler do
       @handler.mustache_class_from_template(@template).should == HelloWorld
       Object.send(:remove_const, :HelloWorld)
     end
+    it "handles templates with dashes in the filename" do
+      class HelloWorld < Stache::Mustache::View; end
+      @template.stub(:virtual_path).and_return 'hello-world'
+      @handler.mustache_class_from_template(@template).should == HelloWorld
+      Object.send(:remove_const, :HelloWorld)
+    end
     it "is clever about folders and such" do
       @template.stub(:virtual_path).and_return("profiles/index")
       module Profiles; class Index < Stache::Mustache::View; end; end


### PR DESCRIPTION
This adds the ability to use template names with dashes instead of underscores (e.g. *some-template.mustache* instead of *some_template.mustache*), and still have their view classes resolved.

