### PR TITLE
Rescue exceptions on class lookups for nested path names.

### DIFF
--- a/lib/stache/mustache/handler.rb
+++ b/lib/stache/mustache/handler.rb
@@ -99,7 +99,8 @@ module Stache
           const_name.constantize
         rescue NameError, LoadError => e
           # Only rescue NameError/LoadError concerning our mustache_class
-          if e.message.match(/#{const_name}$/)
+          e_const_name = e.message.match(/ ([^ ]*)$/)[1]
+          if const_name.match(/#{e_const_name}(::|$)/)
             Stache::Mustache::View
           else
             raise e

--- a/spec/stache/mustache/handler_spec.rb
+++ b/spec/stache/mustache/handler_spec.rb
@@ -31,6 +31,10 @@ describe Stache::Mustache::Handler do
     it "retuns Stache::Mustache::View if it can't find none" do
       @handler.mustache_class_from_template(@template).should == Stache::Mustache::View
     end
+    it "handles nested paths" do
+      @template.stub(:virtual_path).and_return("profiles/sub/index")
+      @handler.mustache_class_from_template(@template).should == Stache::Mustache::View
+    end
     it "reraises error if loaded mustache_class raises a NameError" do
       @template.stub(:virtual_path).and_return("profiles/index")
       module Profiles; end


### PR DESCRIPTION
Stache::Mustache::Handler#mustache_class_from_template does not cope with deeply nested template paths. This commit fixes that.