### PR TITLE
Some quick fixes for Rails 5 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 1.2.0 (2016-12-08)
+
+* Rails 5 functionality
+* Adding controller generators
+* Adding configuration options for `template_extension` and `template_base_class`
+
 ## 1.1.1 (2015-03-19)
 
 * Bugfixes from many new contributors and some expanded test coverage! Thanks very much to all!

--- a/lib/generators/stache.rb
+++ b/lib/generators/stache.rb
@@ -1,0 +1,9 @@
+module Stache
+  module Generators
+    module TemplatePath
+      def source_root
+        @_mustache_source_root ||= File.expand_path(File.join(File.dirname(__FILE__), 'stache', generator_name, 'templates'))
+      end
+    end
+  end
+end

--- a/lib/generators/stache/controller/controller_generator.rb
+++ b/lib/generators/stache/controller/controller_generator.rb
@@ -1,0 +1,40 @@
+require 'generators/stache'
+require 'rails/generators/named_base'
+
+module Stache
+  module Generators
+    class ControllerGenerator < ::Rails::Generators::NamedBase
+      extend TemplatePath
+
+      argument :actions, :type => :array, :default => [], :banner => "action action"
+
+      def create_view_files
+        model_path                  = File.join(class_path, file_name)
+
+        base_mustache_view_path     = File.join("app/views", model_path)
+        empty_directory base_mustache_view_path
+
+        base_mustache_template_path = File.join("app/templates", model_path)
+        empty_directory base_mustache_template_path
+
+        @base_class = Stache.template_base_class
+
+        actions.each do |action|
+          @action  = action
+          mustache_view_path       = File.join(base_mustache_view_path,
+                                                "#{action}.rb")
+          mustache_template_path   = File.join(base_mustache_template_path,
+                                                "#{action}.#{Stache.template_extension}")
+
+          template "view.rb.erb", mustache_view_path
+          template "view.html.mustache.erb", mustache_template_path
+        end
+      end
+
+      protected
+
+      # Methods not to be executed go here
+
+    end
+  end
+end

--- a/lib/generators/stache/controller/templates/view.rb.erb
+++ b/lib/generators/stache/controller/templates/view.rb.erb
@@ -1,0 +1,5 @@
+module <%= singular_name.camelize %>
+  class <%= @action.camelize %> < <%= @base_class %>
+
+  end
+end

--- a/lib/stache/config.rb
+++ b/lib/stache/config.rb
@@ -11,7 +11,7 @@ module Stache
   #   use :mustache # or :handlebars
   # end
   module Config
-    attr_accessor :template_base_path, :shared_path, :wrapper_module_name, :include_path_in_id, :template_cache
+    attr_accessor :template_base_path, :template_extension, :template_base_class, :shared_path, :wrapper_module_name, :include_path_in_id, :template_cache
 
     def configure
       yield self
@@ -23,6 +23,22 @@ module Stache
 
     def template_base_path= path
       @template_base_path = Pathname.new(path)
+    end
+
+    def template_extension
+      @template_extension ||= 'html.mustache'
+    end
+
+    def template_extension= value
+      @template_extension = value
+    end
+
+    def template_base_class
+      @template_base_class ||= '::Stache::Mustache::View'
+    end
+
+    def template_base_class= value
+      @template_base_class = value
     end
 
     def shared_path

--- a/lib/stache/mustache/handler.rb
+++ b/lib/stache/mustache/handler.rb
@@ -38,7 +38,7 @@ module Stache
           mustache.context.push(local_assigns)
           variables = controller.instance_variables
           variables.delete(:@template)
-          if controller.class.protected_instance_variables.defined?
+          if controller.class.respond_to?(:protected_instance_variables)
             variables -= controller.class.protected_instance_variables.to_a
           end
 

--- a/lib/stache/mustache/handler.rb
+++ b/lib/stache/mustache/handler.rb
@@ -38,7 +38,9 @@ module Stache
           mustache.context.push(local_assigns)
           variables = controller.instance_variables
           variables.delete(:@template)
-          variables -= controller.class.protected_instance_variables.to_a
+          if controller.class.protected_instance_variables.defined?
+            variables -= controller.class.protected_instance_variables.to_a
+          end
 
           variables.each do |name|
             mustache.instance_variable_set(name, controller.instance_variable_get(name))

--- a/lib/stache/version.rb
+++ b/lib/stache/version.rb
@@ -1,3 +1,3 @@
 module Stache
-  VERSION = "1.1.1"
+  VERSION = "1.2"
 end

--- a/lib/stache/view_context.rb
+++ b/lib/stache/view_context.rb
@@ -15,7 +15,11 @@ module Stache
     end
 
     def self.included(source)
-      source.send(:before_filter, :set_current_view_context) if source.respond_to?(:before_filter)
+      if source.respond_to?(:before_action) # Rails 4+
+        source.send(:before_action, :set_current_view_context)
+      elsif source.respond_to?(:before_filter) # Rails 3
+        source.send(:before_filter, :set_current_view_context)
+      end
     end
   end
 end

--- a/stache.gemspec
+++ b/stache.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new do |s|
   s.name = 'stache'
   s.version = Stache::VERSION
   s.platform = Gem::Platform::RUBY
-  s.authors = ['Matt Wilson']
+  s.authors = ['Matt Wilson','Michael Bester']
   s.email = 'mhw@hypomodern.com'
   s.homepage = 'http://github.com/agoragames/stache'
   s.summary = %Q{A Rails 3.x and Rails 4.x compatible Mustache/Handlebars template handler}


### PR DESCRIPTION
The `protected_instance_variables` method was [pulled out of the Rails codebase](https://github.com/rails/rails/pull/21298) last September and is no longer present in Rails 5. This PR simply checks for whether or not that method is available before trying to call it so the Stache gem continues to function properly when using it with Rails 5.

Also, the `before_filter` hook was aliased to `before_action` in Rails 4, and will be removed in Rails 5.1, leaving only `before_action`. I've added a check for this case that will maintain compatibility from Rails 3 forward.
