### PR TITLE
Rails 6 change in arity for call

### DIFF
--- a/lib/stache/handlebars/handler.rb
+++ b/lib/stache/handlebars/handler.rb
@@ -63,7 +63,8 @@ module Stache
       end
 
       # In Rails 3.1+, #call takes the place of #compile
-      def self.call(template)
+      # In Rails 6, #call will have an arity of 2
+      def self.call(_, template)
         new.compile(template)
       end
 

--- a/lib/stache/mustache/handler.rb
+++ b/lib/stache/mustache/handler.rb
@@ -82,7 +82,8 @@ module Stache
       end
 
       # In Rails 3.1+, #call takes the place of #compile
-      def self.call(template)
+      # In Rails 6, call will require an arity of 2
+      def self.call(_, template)
         new.compile(template)
       end
 

--- a/lib/stache/mustache/handler.rb
+++ b/lib/stache/mustache/handler.rb
@@ -82,7 +82,7 @@ module Stache
       end
 
       # In Rails 3.1+, #call takes the place of #compile
-      # In Rails 6, call will require an arity of 2
+      # In Rails 6, #call will have an arity of 2
       def self.call(_, template)
         new.compile(template)
       end

--- a/lib/stache/version.rb
+++ b/lib/stache/version.rb
@@ -1,3 +1,3 @@
 module Stache
-  VERSION = "1.2.0"
+  VERSION = "2.0.0"
 end


### PR DESCRIPTION
This change fixes a deprecation warning that I started see while upgrading my app to Rails 6
```
DEPRECATION WARNING: Single arity template handlers are deprecated. Template handlers must
now accept two parameters, the view object and the source for the view object.
Change:
  >> Stache::Mustache::Handler.call(template)
To:
  >> Stache::Mustache::Handler.call(template, source)
 (called from block in <top (required)> at /app/config/initializers/stache.rb:2)
```